### PR TITLE
Define auto sane opts override

### DIFF
--- a/lib/persist.js
+++ b/lib/persist.js
@@ -24,7 +24,7 @@ exports.define = function(name, columnDefs, opts) {
   return Model.define(name, columnDefs, opts);
 };
 
-exports.defineAutoSane = function(name, info, options, callback) {
+exports.defineAutoSane = function(name, info, options, tableOptions, callback) {
   var pluralName = inflection.pluralize(name);
   if (info.tables.hasOwnProperty(pluralName)) {
     var columnDefs = info.tables[pluralName].columns;
@@ -37,8 +37,8 @@ exports.defineAutoSane = function(name, info, options, callback) {
     }
 
     // pass options to Model.define so we can set the Model.tableName directly by
-    // defining options to be { tableName: 'lalala' }
-    var model = Model.define(name, columnDefs, options);
+    // defining tableOptions to be { tableName: 'lalala' }
+    var model = Model.define(name, columnDefs, tableOptions);
     callback(null, model);
   };
 };

--- a/lib/persist.js
+++ b/lib/persist.js
@@ -35,7 +35,10 @@ exports.defineAutoSane = function(name, info, options, callback) {
       }
       columnDefs = newColumnDefs;
     }
-    var model = Model.define(name, columnDefs);
+
+    // pass options to Model.define so we can set the Model.tableName directly by
+    // defining options to be { tableName: 'lalala' }
+    var model = Model.define(name, columnDefs, options);
     callback(null, model);
   };
 };


### PR DESCRIPTION
This is to allow the old autoload to specify a custom table name, to allow us to put database name infront of the table name, so that certain tables can be moved to new mysql databases.